### PR TITLE
:boom: break apart experiments

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 fail_fast: false
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.5.0
+  rev: v4.6.0
   hooks:
     - id: check-added-large-files
       args: ["--maxkb=775"]
@@ -11,7 +11,7 @@ repos:
   hooks:
     - id: reorder-python-imports
 - repo: https://github.com/psf/black
-  rev: 23.12.1
+  rev: 24.3.0
   hooks:
     - id: black
 - repo: https://github.com/pycqa/flake8
@@ -41,7 +41,7 @@ repos:
         additional_dependencies: [tomli]
         args: ["--toml", "pyproject.toml"]
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
     -   id: end-of-file-fixer
         exclude: (.txt|^docs/JOSS1|^docs/JOSS2|^examples/data/)

--- a/mitosis/__init__.py
+++ b/mitosis/__init__.py
@@ -48,7 +48,7 @@ from sqlalchemy import Table
 from sqlalchemy import update
 
 
-class _ExpRun(Protocol):
+class _ExpRun(Protocol):  # Can't handle Varargs
     def __call__(self, *args: Any) -> dict:
         ...
 
@@ -390,7 +390,7 @@ def _run_in_notebook(
     ex: Experiment,
     lookup_params: dict[str, str],
     eval_params: dict[str, str],
-    trials_folder,
+    trials_folder: Path,
     matplotlib_dpi=72,
     debug: bool = False,
 ) -> tuple[nbformat.NotebookNode, Optional[str], Optional[Exception]]:

--- a/mitosis/__init__.py
+++ b/mitosis/__init__.py
@@ -406,7 +406,7 @@ def _run_in_notebook(
             f"with open(r'{trials_folder / (f'results_{order}.dill')}', 'wb') as f:\n"  # noqa E501
             f"    dill.dump(results, f)\n"
             f"print(repr(results))\n"
-            f"in = results"
+            f"in = results['data']"
         )
         step_runner_cells.append(nbformat.v4.new_code_cell(source=code))
 

--- a/mitosis/__init__.py
+++ b/mitosis/__init__.py
@@ -632,7 +632,7 @@ def _prettyprint_config(folder: Path, params: Collection[Parameter]):
 
 
 def parse_steps(
-    keys: list[str], steps: dict[str, list[str]]
+    keys: list[str], steps: dict[str, tuple[str, str]]
 ) -> dict[str, tuple[ExpRun, dict[str, Any]]]:
     """load named steps (in entry point format)"""
 

--- a/mitosis/__init__.py
+++ b/mitosis/__init__.py
@@ -10,6 +10,7 @@ from datetime import timezone
 from importlib.metadata import packages_distributions
 from importlib.metadata import version
 from pathlib import Path
+from random import choices
 from time import process_time
 from types import BuiltinFunctionType
 from types import BuiltinMethodType
@@ -34,7 +35,6 @@ import sqlalchemy as sql
 from nbconvert.exporters import HTMLExporter
 from nbconvert.preprocessors import ExecutePreprocessor
 from nbconvert.writers.files import FilesWriter
-from numpy.random import choice
 from sqlalchemy import Column
 from sqlalchemy import create_engine
 from sqlalchemy import Float
@@ -356,7 +356,7 @@ def run(
     iteration = (
         0 if debug else _id_variant_iteration(trial_db, trials_table, master_variant)
     )
-    rand_key = "".join(choice(list("0123456789abcde"), 6))
+    rand_key = "".join(choices(list("0123456789abcde"), k=6))
 
     out_filename = _create_filename(
         ex.name, group, debug, master_variant, iteration, rand_key, output_extension
@@ -459,7 +459,7 @@ def _run_in_notebook(
 def _create_kernel():
     from ipykernel import kernelapp as app
 
-    kernel_name = "".join(choice(list("0123456789"), 6)) + str(
+    kernel_name = "".join(choices(list("0123456789"), k=6)) + str(
         hash(Path(sys.executable))
     )
     app.launch_new_instance(argv=["install", "--user", "--name", kernel_name])

--- a/mitosis/__init__.py
+++ b/mitosis/__init__.py
@@ -111,16 +111,6 @@ def _locate_trial_folder(
     raise RuntimeError(f"Two or more matches found for {hexstr}")
 
 
-def _split_param_str(paramstr: str) -> tuple[bool, str, str, str]:
-    arg_name, var_name = paramstr.split("=")
-    track = True
-    if arg_name[0] == "+":
-        track = False
-        arg_name = arg_name[1:]
-    ex_step, _, arg_name = arg_name.rpartition(".")
-    return track, ex_step, arg_name, var_name
-
-
 def _lookup_param(
     arg_name: str, var_name: str, lookup_dict: dict[str, Any]
 ) -> Parameter:

--- a/mitosis/__init__.py
+++ b/mitosis/__init__.py
@@ -111,13 +111,14 @@ def _locate_trial_folder(
     raise RuntimeError(f"Two or more matches found for {hexstr}")
 
 
-def _split_param_str(paramstr: str) -> tuple[bool, str, str]:
+def _split_param_str(paramstr: str) -> tuple[bool, str, str, str]:
     arg_name, var_name = paramstr.split("=")
     track = True
     if arg_name[0] == "+":
         track = False
         arg_name = arg_name[1:]
-    return track, arg_name, var_name
+    ex_step, _, arg_name = arg_name.rpartition(".")
+    return track, ex_step, arg_name, var_name
 
 
 def _lookup_param(

--- a/mitosis/__init__.py
+++ b/mitosis/__init__.py
@@ -34,7 +34,6 @@ import sqlalchemy as sql
 from nbconvert.exporters import HTMLExporter
 from nbconvert.preprocessors import ExecutePreprocessor
 from nbconvert.writers.files import FilesWriter
-from numpy import array  # noqa: F401 used in an eval() for result string
 from numpy.random import choice
 from sqlalchemy import Column
 from sqlalchemy import create_engine

--- a/mitosis/__init__.py
+++ b/mitosis/__init__.py
@@ -26,7 +26,6 @@ from typing import Optional
 from typing import Sequence
 
 import dill  # type: ignore
-import nbclient.exceptions
 import nbformat
 import pandas as pd
 import sqlalchemy as sql
@@ -55,7 +54,7 @@ from mitosis._disk import _locate_trial_folder
 
 def trials_columns():
     return [
-        Column("variant", Integer, primary_key=True),
+        Column("variant", String, primary_key=True),
         Column("iteration", Integer, primary_key=True),
         Column("commit", String, nullable=False),
         Column("cpu_time", Float),
@@ -534,7 +533,7 @@ def _log_start_experiment(
     commit: str,
     debug: bool,
 ) -> float:
-    exp_logger.info(f"trial entry: insert--{variant}----{iteration}--{commit}------")
+    exp_logger.info(f"trial entry: insert--{variant}--{iteration}--{commit}--------")
     utc_now = datetime.now(timezone.utc)
     cpu_now = process_time()
     log_msg = (

--- a/mitosis/__init__.py
+++ b/mitosis/__init__.py
@@ -120,7 +120,7 @@ def _split_param_str(paramstr: str) -> tuple[bool, str, str]:
     return track, arg_name, var_name
 
 
-def _resolve_param(
+def _lookup_param(
     arg_name: str, var_name: str, lookup_dict: dict[str, Any]
 ) -> Parameter:
     stored = lookup_dict[arg_name][var_name]

--- a/mitosis/__main__.py
+++ b/mitosis/__main__.py
@@ -140,9 +140,9 @@ def _process_cl_args(args: argparse.Namespace) -> dict[str, Any]:
         )
 
     exp_steps: list[StepDef] = []
-    ep_groups = [_split_param_str(epstr) for epstr in args.eval_param]
-    lp_groups = [_split_param_str(lpstr) for lpstr in args.param]
-
+    # ep_groups = [_split_param_str(epstr) for epstr in args.eval_param]
+    # lp_groups = [_split_param_str(lpstr) for lpstr in args.param]
+    exps = []
     for ex in exps:
         exp_steps.append(
             {
@@ -187,10 +187,10 @@ if __name__ == "__main__":
     main()
 
 
-def normalize_modinput(obj_ref: str) -> dict[str, list[str]]:
+def normalize_modinput(obj_ref: str) -> dict[str, tuple[str, str]]:
     modname, _, qualname = obj_ref.partition(":")
     if qualname:
         sep = ":" + qualname + "."
     else:
         sep = ":"
-    return {obj_ref: [modname + sep + "run", modname + sep + "lookup_dict"]}
+    return {obj_ref: (modname + sep + "run", modname + sep + "lookup_dict")}

--- a/mitosis/__main__.py
+++ b/mitosis/__main__.py
@@ -69,7 +69,10 @@ def _create_parser() -> argparse.ArgumentParser:
         "-e",
         type=str,
         action="append",
-        help="Parameters directly passed on command line",
+        help=(
+            "Parameters directly passed on command line.  Make sure to quote if you"
+            " want argument to evaluate as a string"
+        ),
     )
     parser.add_argument(
         "--param",

--- a/mitosis/__main__.py
+++ b/mitosis/__main__.py
@@ -123,14 +123,13 @@ def _normalize_params(
 
 def _process_cl_args(args: argparse.Namespace) -> dict[str, Any]:
     if args.experiment:
-        exps: list[str] = args.experiment
         if len(args.experiment) > 1:
             raise RuntimeError(
                 "Multi-step experiments not supported yet, check back tomorrow"
             )
         if args.module:
             raise RuntimeError("Cannot use -m option if also passing experiment steps.")
-        all_steps = parse_steps(exps, _disk.load_mitosis_steps())
+        all_steps = parse_steps(args.experiment, _disk.load_mitosis_steps())
     elif args.module:
         all_steps = parse_steps([args.module], normalize_modinput(args.module))
     else:
@@ -141,6 +140,8 @@ def _process_cl_args(args: argparse.Namespace) -> dict[str, Any]:
         )
 
     exp_steps: list[StepDef] = []
+    ep_groups = [_split_param_str(epstr) for epstr in args.eval_param]
+    lp_groups = [_split_param_str(lpstr) for lpstr in args.param]
 
     for ex in exps:
         exp_steps.append(

--- a/mitosis/__main__.py
+++ b/mitosis/__main__.py
@@ -123,7 +123,7 @@ def _normalize_params(
 
 def _process_cl_args(args: argparse.Namespace) -> dict[str, Any]:
     if args.experiment:
-        exps = cast(list[str], args.experiment)
+        exps: list[str] = args.experiment
         if len(args.experiment) > 1:
             raise RuntimeError(
                 "Multi-step experiments not supported yet, check back tomorrow"
@@ -132,7 +132,7 @@ def _process_cl_args(args: argparse.Namespace) -> dict[str, Any]:
             raise RuntimeError("Cannot use -m option if also passing experiment steps.")
         all_steps = parse_steps(exps, _disk.load_mitosis_steps())
     elif args.module:
-        exps = [cast(str, args.module)]
+        all_steps = parse_steps([args.module], normalize_modinput(args.module))
     else:
         raise RuntimeError(
             "Must set either pass a list of experiment steps "
@@ -182,3 +182,12 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
+
+
+def normalize_modinput(obj_ref: str) -> dict[str, list[str]]:
+    modname, _, qualname = obj_ref.partition(":")
+    if qualname:
+        sep = ":" + qualname + "."
+    else:
+        sep = ":"
+    return {obj_ref: [modname + sep + "run", modname + sep + "lookup_dict"]}

--- a/mitosis/__main__.py
+++ b/mitosis/__main__.py
@@ -54,6 +54,7 @@ def _create_parser() -> argparse.ArgumentParser:
         "--eval-param",
         "-e",
         type=str,
+        default=[],
         action="append",
         help=(
             "Parameters directly passed on command line.  Make sure to quote if you"
@@ -64,6 +65,7 @@ def _create_parser() -> argparse.ArgumentParser:
         "--param",
         "-p",
         action="append",
+        default=[],
         help=(
             "Name of parameters to use with this trial, in format 'key=value'\ne.g."
             "--param solver=solver_1\nKeys must be understood by the experiment"

--- a/mitosis/__main__.py
+++ b/mitosis/__main__.py
@@ -7,19 +7,11 @@ from typing import cast
 from typing import NamedTuple
 
 from . import _disk
-from . import ExpRun
-from . import Parameter
 from . import parse_steps
 from . import run
-
-
-class ExpStep(NamedTuple):
-    name: str
-    module: ExpRun
-    lookup: dict[str, Any]
-    group: str | None
-    args: list[Parameter]
-    untracked_args: list[str]
+from ._typing import ExpRun
+from ._typing import ExpStep
+from ._typing import Parameter
 
 
 def _create_parser() -> argparse.ArgumentParser:
@@ -193,7 +185,7 @@ def _process_cl_args(args: argparse.Namespace) -> dict[str, Any]:
     else:
         folder = Path(args.folder)
     return {
-        "ex": exp_steps,
+        "steps": exp_steps,
         "debug": args.debug,
         "trials_folder": folder,
     }

--- a/mitosis/_disk.py
+++ b/mitosis/_disk.py
@@ -1,5 +1,6 @@
 from functools import lru_cache
 from pathlib import Path
+from typing import Optional
 
 import git
 import toml
@@ -46,3 +47,22 @@ def _choose_toml(filename: Path | str | None) -> Path:
     elif not Path(filename).is_absolute():
         return directory / filename
     return Path(filename)
+
+
+def _locate_trial_folder(
+    hexstr: str, *, trials_folder: Optional[Path | str] = None
+) -> Path:
+    if trials_folder is None:
+        trials_folder = Path().absolute()
+    else:
+        trials_folder = Path(trials_folder).resolve()
+    matches = trials_folder.glob(f"*{hexstr}")
+    try:
+        first = next(matches)
+    except StopIteration:
+        raise FileNotFoundError(f"Could not find a trial that matched {hexstr}")
+    try:
+        next(matches)
+    except StopIteration:
+        return first
+    raise RuntimeError(f"Two or more matches found for {hexstr}")

--- a/mitosis/_disk.py
+++ b/mitosis/_disk.py
@@ -14,7 +14,7 @@ def load_mitosis_steps(
     Args:
         pyproj_file:
             Local or absolute path to pyproject file.  default is pyproject.toml
-            if local path or default, use current working directory
+            if local path or default, use current git repo's top level directory
     Raises:
         Runtime error if cannot load steps, or if they are badly formed.
     """
@@ -38,12 +38,11 @@ def get_repo() -> git.Repo:
     return repo
 
 
-def _choose_toml(filename: Path | str) -> Path:
+def _choose_toml(filename: Path | str | None) -> Path:
     repo = get_repo()
     directory = Path(repo.working_dir)
     if filename is None:
-        filename = directory / "pyproject.toml"
-    else:
-        if not Path(filename).is_absolute():
-            filename = directory / filename
+        return directory / "pyproject.toml"
+    elif not Path(filename).is_absolute():
+        return directory / filename
     return Path(filename)

--- a/mitosis/_disk.py
+++ b/mitosis/_disk.py
@@ -1,0 +1,44 @@
+from functools import lru_cache
+from pathlib import Path
+
+import git
+import toml
+
+
+@lru_cache
+def load_mitosis_steps(
+    proj_file: Path | str = "pyproject.toml",
+) -> dict[str, list[str]]:
+    """Load experiment steps saved in pyproject.toml (or other config)
+
+    Args:
+        pyproj_file:
+            Local or absolute path to pyproject file.  default is pyproject.toml
+            if local path or default, use current working directory
+    """
+    proj_file = _choose_toml(proj_file)
+    with open(proj_file, "r") as f:
+        config = toml.load(f)
+    try:
+        return config["tool"]["mitosis"]["steps"]
+    except KeyError:
+        raise RuntimeError(
+            f"{proj_file.absolute()} does not have a tools.mitosis.steps table"
+        )
+
+
+@lru_cache
+def get_repo() -> git.Repo:
+    repo = git.Repo(Path.cwd(), search_parent_directories=True)
+    return repo
+
+
+def _choose_toml(filename: Path | str) -> Path:
+    repo = get_repo()
+    directory = Path(repo.working_dir)
+    if filename is None:
+        filename = directory / "pyproject.toml"
+    else:
+        if not Path(filename).is_absolute():
+            filename = directory / filename
+    return Path(filename)

--- a/mitosis/_typing.py
+++ b/mitosis/_typing.py
@@ -1,0 +1,17 @@
+from abc import ABCMeta
+from types import ModuleType
+from typing import Any
+from typing import Protocol
+
+
+class ExpRun(Protocol):  # Can't handle Varargs
+    def __call__(self, *args: Any) -> dict:
+        ...
+
+
+class Experiment(ModuleType, metaclass=ABCMeta):
+    __name__: str
+    __file__: str
+    name: str
+    lookup_dict: dict[str, dict[str, Any]]
+    run: ExpRun

--- a/mitosis/_typing.py
+++ b/mitosis/_typing.py
@@ -3,12 +3,13 @@ from dataclasses import dataclass
 from dataclasses import field
 from types import ModuleType
 from typing import Any
+from typing import Callable
 from typing import NamedTuple
-from typing import Protocol
+from typing import ParamSpec
 
 
-class ExpRun(Protocol):  # Can't handle Varargs
-    def __call__(self, *args: Any, **kwargs: Any) -> dict: ...  # noqa: E704
+P = ParamSpec("P")
+ExpRun = Callable[P, dict]
 
 
 class Experiment(ModuleType, metaclass=ABCMeta):

--- a/mitosis/_typing.py
+++ b/mitosis/_typing.py
@@ -41,7 +41,9 @@ class Parameter:
 class ExpStep(NamedTuple):
     name: str
     action: ExpRun
+    action_ref: str
     lookup: dict[str, Any]
+    lookup_ref: str
     group: str | None
     args: list[Parameter]
     untracked_args: list[str]

--- a/mitosis/_typing.py
+++ b/mitosis/_typing.py
@@ -8,8 +8,7 @@ from typing import Protocol
 
 
 class ExpRun(Protocol):  # Can't handle Varargs
-    def __call__(self, *args: Any) -> dict:
-        ...
+    def __call__(self, *args: Any, **kwargs: Any) -> dict: ...  # noqa: E704
 
 
 class Experiment(ModuleType, metaclass=ABCMeta):

--- a/mitosis/_typing.py
+++ b/mitosis/_typing.py
@@ -1,6 +1,9 @@
 from abc import ABCMeta
+from dataclasses import dataclass
+from dataclasses import field
 from types import ModuleType
 from typing import Any
+from typing import NamedTuple
 from typing import Protocol
 
 
@@ -15,3 +18,30 @@ class Experiment(ModuleType, metaclass=ABCMeta):
     name: str
     lookup_dict: dict[str, dict[str, Any]]
     run: ExpRun
+
+
+@dataclass
+class Parameter:
+    """An experimental parameter
+
+    Arguments:
+        var_name: short name for the variant (particular values) across use cases
+        arg_name: name of arg known to experiment
+        vals: value of the parameter
+        eval: whether variant name should be evaluated or looked up.
+    """
+
+    var_name: str
+    arg_name: str
+    vals: Any
+    # > 3.10 only: https://stackoverflow.com/a/49911616/534674
+    evaluate: bool = field(default=False, kw_only=True)
+
+
+class ExpStep(NamedTuple):
+    name: str
+    action: ExpRun
+    lookup: dict[str, Any]
+    group: str | None
+    args: list[Parameter]
+    untracked_args: list[str]

--- a/mitosis/tests/mock_experiment.py
+++ b/mitosis/tests/mock_experiment.py
@@ -7,5 +7,13 @@ def run(**kwargs):
     return {"main": 0}
 
 
-name = "MockModuleExperiment"
 lookup_dict = {"foo": {"test": 2}}
+
+
+class MockExp:
+    class MockExpInner:
+        lookup_dict: dict[str, dict[str, int]] = lookup_dict
+
+        @staticmethod
+        def run():
+            return {"main": 0}

--- a/mitosis/tests/mock_legacy.py
+++ b/mitosis/tests/mock_legacy.py
@@ -8,12 +8,3 @@ def run(**kwargs):
 
 
 lookup_dict = {"foo": {"test": 2}}
-
-
-class MockExp:
-    class MockExpInner:
-        lookup_dict: dict[str, dict[str, int]] = lookup_dict
-
-        @staticmethod
-        def run():
-            return {"main": 0}

--- a/mitosis/tests/mock_paper.py
+++ b/mitosis/tests/mock_paper.py
@@ -1,0 +1,3 @@
+data_config = {"length": {"test": 5}}
+
+meth_config = {"metric": {"test": "len"}}

--- a/mitosis/tests/mock_part1.py
+++ b/mitosis/tests/mock_part1.py
@@ -7,8 +7,10 @@ from numpy.typing import NDArray
 
 class Klass:
     @staticmethod
-    def gen_data(length: int) -> dict[str, NDArray[np.floating[NBitBase]]]:
+    def gen_data(
+        length: int, extra: bool = False
+    ) -> dict[str, NDArray[np.floating[NBitBase]] | bool]:
         getLogger(__name__).info("This is run every time")
         getLogger(__name__).debug("This is run in debug mode only")
 
-        return {"data": np.ones(length, dtype=np.float_)}
+        return {"data": np.ones(length, dtype=np.float_), "extra": extra}

--- a/mitosis/tests/mock_part1.py
+++ b/mitosis/tests/mock_part1.py
@@ -1,0 +1,14 @@
+from logging import getLogger
+
+import numpy as np
+from numpy.typing import NBitBase
+from numpy.typing import NDArray
+
+
+class Klass:
+    @staticmethod
+    def gen_data(length: int) -> dict[str, NDArray[np.floating[NBitBase]]]:
+        getLogger(__name__).info("This is run every time")
+        getLogger(__name__).debug("This is run in debug mode only")
+
+        return {"data": np.ones(length, dtype=np.float_)}

--- a/mitosis/tests/mock_part2.py
+++ b/mitosis/tests/mock_part2.py
@@ -1,0 +1,14 @@
+from typing import Literal
+
+import numpy as np
+from numpy.typing import NBitBase
+from numpy.typing import NDArray
+
+
+def fit_and_score(
+    data: NDArray[np.floating[NBitBase]], metric: Literal["len"] | Literal["zero"]
+) -> dict[str, float]:
+    if metric == "len":
+        return {"main": len(data)}
+    elif metric == "zero":
+        return {"main": 0}

--- a/mitosis/tests/mock_part2.py
+++ b/mitosis/tests/mock_part2.py
@@ -1,3 +1,4 @@
+from typing import Any
 from typing import Literal
 
 import numpy as np
@@ -12,3 +13,7 @@ def fit_and_score(
         return {"main": len(data)}
     elif metric == "zero":
         return {"main": 0}
+
+
+def bad_runnable(*args: Any, **kwargs: Any):
+    return 1  # not a dict with key "main"

--- a/mitosis/tests/pyproject_malformed.toml
+++ b/mitosis/tests/pyproject_malformed.toml
@@ -1,0 +1,2 @@
+[tool.mitosis.steps]
+data = ["data.library:gen_data"]

--- a/mitosis/tests/test_all.py
+++ b/mitosis/tests/test_all.py
@@ -9,7 +9,6 @@ import pytest
 import mitosis
 from mitosis import _disk
 from mitosis import parse_steps
-from mitosis.__main__ import _normalize_params
 from mitosis.__main__ import _split_param_str
 from mitosis.__main__ import normalize_modinput
 from mitosis.tests import bad_return_experiment
@@ -163,13 +162,6 @@ def test_split_param_str():
     assert result == ("a", True, "b", "c")
 
 
-def test_process_cl_params(tmp_path):
-    processed = _normalize_params({}, ['mystr="hi"', "+myint=2"], [])
-    assert all(isinstance(param.vals, str) for param in processed[0])
-    # Should handle without errors
-    _normalize_params({}, (), ())
-
-
 def test_malfored_return_experiment(tmp_path):
     with pytest.raises(nbclient.exceptions.CellExecutionError):
         mitosis.run(
@@ -185,8 +177,8 @@ def test_load_toml():
     tomlfile = parent / "test_pyproject.toml"
     result = _disk.load_mitosis_steps(tomlfile)
     expected = {
-        "data": ["data.library:gen_data", "paper.config:data_config"],
-        "fit_eval": ["meth_lib:fit_and_score", "paper.config:meth_config"],
+        "data": ("data.library:gen_data", "paper.config:data_config"),
+        "fit_eval": ("meth_lib:fit_and_score", "paper.config:meth_config"),
     }
     assert result == expected
 

--- a/mitosis/tests/test_all.py
+++ b/mitosis/tests/test_all.py
@@ -12,9 +12,9 @@ from mitosis import parse_steps
 from mitosis.__main__ import _split_param_str
 from mitosis.__main__ import normalize_modinput
 from mitosis.tests import bad_return_experiment
-from mitosis.tests import mock_experiment
+from mitosis.tests import mock_legacy
 
-mock_experiment = cast(mitosis.Experiment, mock_experiment)
+mock_legacy = cast(mitosis.Experiment, mock_legacy)
 bad_return_experiment = cast(mitosis.Experiment, bad_return_experiment)
 
 
@@ -110,6 +110,7 @@ def fake_lookup_param():
     return mitosis.Parameter("test", "foo", 2, evaluate=False)
 
 
+@pytest.mark.skip
 @pytest.mark.parametrize(
     "param",
     (
@@ -119,22 +120,23 @@ def fake_lookup_param():
 )
 def test_empty_mod_experiment(tmp_path, param):
     mitosis.run(
-        mock_experiment,
+        mock_legacy,
         debug=True,
         trials_folder=tmp_path,
         params=[param],
     )
 
 
+@pytest.mark.skip
 def test_empty_mod_logging_debug(tmp_path):
     hexstr = mitosis.run(
-        mock_experiment,
+        mock_legacy,
         debug=True,
         trials_folder=tmp_path,
         params=[],
     )
     trial_folder = mitosis._locate_trial_folder(hexstr, trials_folder=tmp_path)
-    with open(trial_folder / f"{mock_experiment.__name__}.log") as f:
+    with open(trial_folder / f"{mock_legacy.__name__}.log") as f:
         log_str = "".join(f.readlines())
     assert "This is run every time" in log_str
     assert "This is run in debug mode only" in log_str
@@ -143,13 +145,13 @@ def test_empty_mod_logging_debug(tmp_path):
 @pytest.mark.clean
 def test_empty_mod_logging(tmp_path):
     hexstr = mitosis.run(
-        mock_experiment,
+        mock_legacy,
         debug=False,
         trials_folder=tmp_path,
         params=[],
     )
     trial_folder = mitosis._locate_trial_folder(hexstr, trials_folder=tmp_path)
-    with open(trial_folder / f"{mock_experiment.__name__}.log") as f:
+    with open(trial_folder / f"{mock_legacy.__name__}.log") as f:
         log_str = "".join(f.readlines())
     assert "This is run every time" in log_str
     assert "This is run in debug mode only" not in log_str
@@ -162,6 +164,7 @@ def test_split_param_str():
     assert result == ("a", True, "b", "c")
 
 
+@pytest.mark.skip
 def test_malfored_return_experiment(tmp_path):
     with pytest.raises(nbclient.exceptions.CellExecutionError):
         mitosis.run(
@@ -177,8 +180,14 @@ def test_load_toml():
     tomlfile = parent / "test_pyproject.toml"
     result = _disk.load_mitosis_steps(tomlfile)
     expected = {
-        "data": ("data.library:gen_data", "paper.config:data_config"),
-        "fit_eval": ("meth_lib:fit_and_score", "paper.config:meth_config"),
+        "data": (
+            "mitosis.tests.mock_part1:Klass.gen_data",
+            "mitosis.tests.mock_paper:data_config",
+        ),
+        "fit_eval": (
+            "mitosis.tests.mock_part2:fit_and_score",
+            "mitosis.tests.mock_paper:meth_config",
+        ),
     }
     assert result == expected
 

--- a/mitosis/tests/test_all.py
+++ b/mitosis/tests/test_all.py
@@ -10,6 +10,7 @@ import mitosis
 from mitosis import _disk
 from mitosis import parse_steps
 from mitosis.__main__ import _normalize_params
+from mitosis.__main__ import _split_param_str
 from mitosis.__main__ import normalize_modinput
 from mitosis.tests import bad_return_experiment
 from mitosis.tests import mock_experiment
@@ -153,6 +154,13 @@ def test_empty_mod_logging(tmp_path):
         log_str = "".join(f.readlines())
     assert "This is run every time" in log_str
     assert "This is run in debug mode only" not in log_str
+
+
+def test_split_param_str():
+    result = _split_param_str("+a=b")
+    assert result == (False, "", "a", "b")
+    result = _split_param_str("a.b=c")
+    assert result == (True, "a", "b", "c")
 
 
 def test_process_cl_params(tmp_path):

--- a/mitosis/tests/test_all.py
+++ b/mitosis/tests/test_all.py
@@ -158,9 +158,9 @@ def test_empty_mod_logging(tmp_path):
 
 def test_split_param_str():
     result = _split_param_str("+a=b")
-    assert result == (False, "", "a", "b")
+    assert result == ("", False, "a", "b")
     result = _split_param_str("a.b=c")
-    assert result == (True, "a", "b", "c")
+    assert result == ("a", True, "b", "c")
 
 
 def test_process_cl_params(tmp_path):
@@ -231,10 +231,3 @@ def test_normalize_modinput():
             "mitosis.tests.mock_experiment:MockExp.MockExpInner.lookup_dict",
         )
     }
-
-
-# def run(foo):
-#     return {"main": 0}
-
-
-# name = "MockModuleExperiment"

--- a/mitosis/tests/test_all.py
+++ b/mitosis/tests/test_all.py
@@ -156,10 +156,10 @@ def test_empty_mod_logging(tmp_path):
 
 
 def test_process_cl_params(tmp_path):
-    processed = _normalize_params(['mystr="hi"', "+myint=2"], [], {})
+    processed = _normalize_params({}, ['mystr="hi"', "+myint=2"], [])
     assert all(isinstance(param.vals, str) for param in processed[0])
     # Should handle without errors
-    _normalize_params(None, None, {})
+    _normalize_params({}, (), ())
 
 
 def test_malfored_return_experiment(tmp_path):

--- a/mitosis/tests/test_all.py
+++ b/mitosis/tests/test_all.py
@@ -1,4 +1,3 @@
-import subprocess
 import sys
 from types import ModuleType
 from typing import cast
@@ -167,25 +166,6 @@ def test_malfored_return_experiment(tmp_path):
             trials_folder=tmp_path,
             params=[],
         )
-
-
-def test_cli(tmp_path):
-    subprocess.run(
-        ["which", "python3"],
-    )
-    subprocess.run(
-        [
-            "python3",
-            "-m",
-            "mitosis",
-            "mitosis.tests.mock_experiment",
-            "--param",
-            "foo=test",
-            "-e",
-            "seed=1" "-F",
-            str(tmp_path),
-        ],
-    )
 
 
 def run(foo):

--- a/mitosis/tests/test_all.py
+++ b/mitosis/tests/test_all.py
@@ -1,7 +1,6 @@
 import sys
 from pathlib import Path
 from types import ModuleType
-from typing import cast
 
 import nbclient.exceptions
 import pytest
@@ -13,9 +12,6 @@ from mitosis.__main__ import _split_param_str
 from mitosis.__main__ import normalize_modinput
 from mitosis.tests import bad_return_experiment
 from mitosis.tests import mock_legacy
-
-mock_legacy = cast(mitosis.Experiment, mock_legacy)
-bad_return_experiment = cast(mitosis.Experiment, bad_return_experiment)
 
 
 def test_reproduceable_dict():
@@ -110,7 +106,6 @@ def fake_lookup_param():
     return mitosis.Parameter("test", "foo", 2, evaluate=False)
 
 
-@pytest.mark.skip
 @pytest.mark.parametrize(
     "param",
     (
@@ -127,7 +122,6 @@ def test_empty_mod_experiment(tmp_path, param):
     )
 
 
-@pytest.mark.skip
 def test_empty_mod_logging_debug(tmp_path):
     hexstr = mitosis.run(
         mock_legacy,
@@ -164,7 +158,6 @@ def test_split_param_str():
     assert result == ("a", True, "b", "c")
 
 
-@pytest.mark.skip
 def test_malfored_return_experiment(tmp_path):
     with pytest.raises(nbclient.exceptions.CellExecutionError):
         mitosis.run(

--- a/mitosis/tests/test_all.py
+++ b/mitosis/tests/test_all.py
@@ -10,6 +10,7 @@ import mitosis
 from mitosis import _disk
 from mitosis import parse_steps
 from mitosis.__main__ import _normalize_params
+from mitosis.__main__ import normalize_modinput
 from mitosis.tests import bad_return_experiment
 from mitosis.tests import mock_experiment
 
@@ -194,8 +195,28 @@ def test_parse_steps():
     assert result == {"want": (version, vars(builtins))}
 
 
-def run(foo):
-    return {"main": 0}
+def test_normalize_modinput():
+    modinput = "mitosis.tests.mock_experiment"
+    result = normalize_modinput(modinput)
+    assert result == {
+        "mitosis.tests.mock_experiment": [
+            "mitosis.tests.mock_experiment:run",
+            "mitosis.tests.mock_experiment:lookup_dict",
+        ]
+    }
+    # if modinput is an object, connect to run and lookup_dict with . not :
+    modinput = "mitosis.tests.mock_experiment:MockExp.MockExpInner"
+    result = normalize_modinput(modinput)
+    assert result == {
+        "mitosis.tests.mock_experiment:MockExp.MockExpInner": [
+            "mitosis.tests.mock_experiment:MockExp.MockExpInner.run",
+            "mitosis.tests.mock_experiment:MockExp.MockExpInner.lookup_dict",
+        ]
+    }
 
 
-name = "MockModuleExperiment"
+# def run(foo):
+#     return {"main": 0}
+
+
+# name = "MockModuleExperiment"

--- a/mitosis/tests/test_all.py
+++ b/mitosis/tests/test_all.py
@@ -8,7 +8,7 @@ import pytest
 
 import mitosis
 from mitosis import _disk
-from mitosis import parse_steps
+from mitosis import unpack
 from mitosis.__main__ import _split_param_str
 from mitosis.__main__ import normalize_modinput
 from mitosis.tests import bad_return_experiment
@@ -202,16 +202,12 @@ def test_load_bad_toml():
         _disk.load_mitosis_steps(tomlfile)
 
 
-def test_parse_steps():
+def test_unpack():
     from importlib.metadata import version
-    import builtins
 
-    steps = {
-        "want": (("importlib.metadata:version"), ("builtins:__dict__")),
-        "dont_want": (("foo:bar"), ("baz.qux")),
-    }
-    result = parse_steps(["want"], steps)
-    assert result == {"want": (version, vars(builtins))}
+    obj_ref = "importlib.metadata:version"
+    result = unpack(obj_ref)
+    assert result is version
 
 
 def test_normalize_modinput():

--- a/mitosis/tests/test_all.py
+++ b/mitosis/tests/test_all.py
@@ -10,7 +10,6 @@ from mitosis import _disk
 from mitosis import unpack
 from mitosis._typing import ExpStep
 from mitosis._typing import Parameter
-from mitosis.tests import mock_legacy
 from mitosis.tests import mock_paper
 from mitosis.tests import mock_part1
 from mitosis.tests import mock_part2
@@ -143,7 +142,7 @@ def test_mock_experiment(mock_steps, tmp_path):
     assert len(data[1]["data"]) == 5
 
 
-def test_empty_mod_logging_debug(mock_steps, tmp_path):
+def test_mod_logging_debug(mock_steps, tmp_path):
     hexstr = mitosis.run(
         mock_steps,
         debug=True,
@@ -157,14 +156,14 @@ def test_empty_mod_logging_debug(mock_steps, tmp_path):
 
 
 @pytest.mark.clean
-def test_empty_mod_logging(mock_steps, tmp_path):
+def test_mod_logging(mock_steps, tmp_path):
     hexstr = mitosis.run(
         mock_steps,
         debug=False,
         trials_folder=tmp_path,
     )
     trial_folder = _disk._locate_trial_folder(hexstr, trials_folder=tmp_path)
-    with open(trial_folder / f"{mock_legacy.__name__}.log") as f:
+    with open(trial_folder / "experiment.log", "r") as f:
         log_str = "".join(f.readlines())
     assert "This is run every time" in log_str
     assert "This is run in debug mode only" not in log_str

--- a/mitosis/tests/test_all.py
+++ b/mitosis/tests/test_all.py
@@ -191,6 +191,16 @@ def test_load_toml():
     assert result == expected
 
 
+def test_load_bad_toml():
+    parent = Path(__file__).resolve().parent
+    tomlfile = parent / "pyproject_missing.toml"
+    with pytest.raises(RuntimeError, match="does not have a tools"):
+        _disk.load_mitosis_steps(tomlfile)
+    tomlfile = parent / "pyproject_malformed.toml"
+    with pytest.raises(RuntimeError, match="table is malformed"):
+        _disk.load_mitosis_steps(tomlfile)
+
+
 def test_parse_steps():
     from importlib.metadata import version
     import builtins
@@ -207,19 +217,19 @@ def test_normalize_modinput():
     modinput = "mitosis.tests.mock_experiment"
     result = normalize_modinput(modinput)
     assert result == {
-        "mitosis.tests.mock_experiment": [
+        "mitosis.tests.mock_experiment": (
             "mitosis.tests.mock_experiment:run",
             "mitosis.tests.mock_experiment:lookup_dict",
-        ]
+        )
     }
     # if modinput is an object, connect to run and lookup_dict with . not :
     modinput = "mitosis.tests.mock_experiment:MockExp.MockExpInner"
     result = normalize_modinput(modinput)
     assert result == {
-        "mitosis.tests.mock_experiment:MockExp.MockExpInner": [
+        "mitosis.tests.mock_experiment:MockExp.MockExpInner": (
             "mitosis.tests.mock_experiment:MockExp.MockExpInner.run",
             "mitosis.tests.mock_experiment:MockExp.MockExpInner.lookup_dict",
-        ]
+        )
     }
 
 

--- a/mitosis/tests/test_cli.py
+++ b/mitosis/tests/test_cli.py
@@ -4,6 +4,8 @@ import pytest
 
 from mitosis.__main__ import _create_parser
 from mitosis.__main__ import _process_cl_args
+from mitosis.__main__ import _split_param_str
+from mitosis.__main__ import normalize_modinput
 from mitosis.tests.mock_legacy import lookup_dict
 from mitosis.tests.mock_legacy import run
 from mitosis.tests.mock_paper import meth_config
@@ -77,3 +79,30 @@ def test_argparse_main():
     assert args.folder is None
     assert len(args.eval_param) == 2
     assert len(args.param) == 3
+
+
+def test_split_param_str():
+    result = _split_param_str("+a=b")
+    assert result == ("", False, "a", "b")
+    result = _split_param_str("a.b=c")
+    assert result == ("a", True, "b", "c")
+
+
+def test_normalize_modinput():
+    modinput = "mitosis.tests.mock_experiment"
+    result = normalize_modinput(modinput)
+    assert result == {
+        "mitosis.tests.mock_experiment": (
+            "mitosis.tests.mock_experiment:run",
+            "mitosis.tests.mock_experiment:lookup_dict",
+        )
+    }
+    # if modinput is an object, connect to run and lookup_dict with . not :
+    modinput = "mitosis.tests.mock_experiment:MockExp.MockExpInner"
+    result = normalize_modinput(modinput)
+    assert result == {
+        "mitosis.tests.mock_experiment:MockExp.MockExpInner": (
+            "mitosis.tests.mock_experiment:MockExp.MockExpInner.run",
+            "mitosis.tests.mock_experiment:MockExp.MockExpInner.lookup_dict",
+        )
+    }

--- a/mitosis/tests/test_cli.py
+++ b/mitosis/tests/test_cli.py
@@ -49,15 +49,31 @@ def test_experiment_arg():
     assert id(result["steps"][1].lookup) == id(meth_config)
 
 
-@pytest.mark.skip
-def test_argparse_types():
+def test_argparse_options():
     parser = _create_parser()
-    args = parser.parse_args("stuff")
-    expected = None
-    assert args
-    assert expected is None
+    args = parser.parse_args(
+        ["-m", "mod", "-d", "--config", "foo.toml", "-F", "foo/bar"]
+    )
+    assert args.experiment == []
+    assert args.module == "mod"
+    assert args.debug is True
+    assert args.config == "foo.toml"
+    assert args.folder == "foo/bar"
+    assert args.eval_param == []
+    assert args.param == []
 
 
-@pytest.mark.skip
-def test_argparse_defaults():
-    pass
+def test_argparse_main():
+    parser = _create_parser()
+    args = parser.parse_args(
+        [
+            "step1", "step2", "-e", "a=1", "-e", "b=2", "-p", "c=d", "-p", "e=f", "-p", "g=h"  # fmt: skip; # noqa: E501
+        ]
+    )
+    assert args.experiment == ["step1", "step2"]
+    assert args.module is None
+    assert args.debug is False
+    assert args.config == "pyproject.toml"
+    assert args.folder is None
+    assert len(args.eval_param) == 2
+    assert len(args.param) == 3

--- a/mitosis/tests/test_cli.py
+++ b/mitosis/tests/test_cli.py
@@ -1,0 +1,63 @@
+from argparse import Namespace
+
+import pytest
+
+from mitosis.__main__ import _create_parser
+from mitosis.__main__ import _process_cl_args
+from mitosis.tests.mock_legacy import lookup_dict
+from mitosis.tests.mock_legacy import run
+from mitosis.tests.mock_paper import meth_config
+from mitosis.tests.mock_part1 import Klass
+
+
+@pytest.mark.parametrize(
+    ("params", "eval_params"),
+    (([], []), (["foo=test"], []), ([], ["seed=1"])),
+    ids=("no args", "lookup", "eval"),
+)
+def test_legacy_module(params, eval_params):
+    args = Namespace(
+        experiment=[],
+        module="mitosis.tests.mock_legacy",
+        debug=True,
+        config="pyproject.toml",
+        folder=None,
+        eval_param=eval_params,
+        param=params,
+    )
+    result = _process_cl_args(args)
+    assert len(result["steps"]) == 1
+    assert result["steps"][0].name == "mitosis.tests.mock_legacy"
+    assert result["steps"][0].action == run
+    assert id(result["steps"][0].lookup) == id(lookup_dict)
+
+
+def test_experiment_arg():
+    args = Namespace(
+        experiment=["data", "fit_eval"],
+        module=None,
+        debug=True,
+        config="mitosis/tests/test_pyproject.toml",
+        folder=None,
+        eval_param=["data.extra=True"],
+        param=["data.length=test", "fit_eval.metric=test"],
+    )
+    result = _process_cl_args(args)
+    assert len(result["steps"]) == 2
+    assert [step.name for step in result["steps"]] == ["data", "fit_eval"]
+    assert result["steps"][0].action == Klass.gen_data
+    assert id(result["steps"][1].lookup) == id(meth_config)
+
+
+@pytest.mark.skip
+def test_argparse_types():
+    parser = _create_parser()
+    args = parser.parse_args("stuff")
+    expected = None
+    assert args
+    assert expected is None
+
+
+@pytest.mark.skip
+def test_argparse_defaults():
+    pass

--- a/mitosis/tests/test_pyproject.toml
+++ b/mitosis/tests/test_pyproject.toml
@@ -1,0 +1,3 @@
+[tool.mitosis.steps]
+data = ["data.library:gen_data", "paper.config:data_config"]
+fit_eval = ["meth_lib:fit_and_score", "paper.config:meth_config"]

--- a/mitosis/tests/test_pyproject.toml
+++ b/mitosis/tests/test_pyproject.toml
@@ -1,3 +1,9 @@
 [tool.mitosis.steps]
-data = ["data.library:gen_data", "paper.config:data_config"]
-fit_eval = ["meth_lib:fit_and_score", "paper.config:meth_config"]
+data = [
+    "mitosis.tests.mock_part1:Klass.gen_data",
+    "mitosis.tests.mock_paper:data_config"
+]
+fit_eval = [
+    "mitosis.tests.mock_part2:fit_and_score",
+    "mitosis.tests.mock_paper:meth_config"
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,8 @@ dependencies = [
   "nbformat",
   "pandas",
   "sqlalchemy",
-  "toml"
+  "toml",
+  "types-toml",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,10 +42,9 @@ dependencies = [
   "nbconvert",
   "nbclient",
   "nbformat",
-  "numpy",
   "pandas",
-  "papermill",
   "sqlalchemy",
+  "toml"
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,3 +98,7 @@ markers = ["clean"]
 
 [tool.codespell]
 ignore-words-list = "raison"
+
+[tool.mitosis.steps]
+data = ["foo", "bar"]
+fit_eval = ["baz"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,3 @@ markers = ["clean"]
 
 [tool.codespell]
 ignore-words-list = "raison"
-
-[tool.mitosis.steps]
-data = ["foo", "bar"]
-fit_eval = ["baz"]


### PR DESCRIPTION
This change breaks apart the concept of an "experiment" in two major ways:
* Experiments are rebranded into Steps, so that they can be combined in new ways
* The steps load their callable and lookup dictionaries from potentially different places.

The meanings of steps (their name, their callables, and their lookup dictionaries) are all specified on the pyproject.toml.  The benefits of using declarative syntax are many.

This allows a few different, cool approaches:
* Typing of steps now supports subtyping of callables (a little), to help wrappers.
* Keeping the lookup dictionary of variant names separate from the experiments themselves.

