### PR TITLE
Print logs once

### DIFF
--- a/mitosis/tests/test_all.py
+++ b/mitosis/tests/test_all.py
@@ -1,4 +1,5 @@
 import pickle
+import re
 import sys
 from pathlib import Path
 from types import ModuleType
@@ -167,9 +168,9 @@ def test_mod_metadata_debug(mock_steps, tmp_path):
     )
     trial_folder = _disk.locate_trial_folder(hexstr, trials_folder=tmp_path)
     with open(trial_folder / "experiment.log", "r") as f:
-        log_str = "".join(f.readlines())
-    assert "This is run every time" in log_str
-    assert "This is run in debug mode only" in log_str
+        log_str = "\n".join(f.readlines())
+    assert len(re.findall("This is run every time", log_str)) == 1
+    assert len(re.findall("This is run in debug mode only", log_str)) == 1
     with open(trial_folder / "config.txt") as f:
         config_lines = f.readlines()
     config_params = [eval(line) for line in config_lines]
@@ -186,9 +187,9 @@ def test_mod_metadata(mock_steps, tmp_path):
     )
     trial_folder = _disk.locate_trial_folder(hexstr, trials_folder=tmp_path)
     with open(trial_folder / "experiment.log", "r") as f:
-        log_str = "".join(f.readlines())
-    assert "This is run every time" in log_str
-    assert "This is run in debug mode only" not in log_str
+        log_str = "\n".join(f.readlines())
+    assert len(re.findall("This is run every time", log_str)) == 1
+    assert len(re.findall("This is run in debug mode only", log_str)) == 0
     with open(trial_folder / "config.txt") as f:
         config_lines = f.readlines()
     config_params = [eval(line) for line in config_lines]


### PR DESCRIPTION
Previously, experiment log handlers were added not at root logger, but at the
logger for each step's module.  Later, we realized we wanted to capture all
logs, so the handlers instead got added to the root logger.  However, when
there was more one step, this added an identical handler to root for each step,
thus emitting copies of same logrecords.

Now, the logging configuration is only handled in the trial setup.

Tests modified as well to check not only that requisite message is in log, but that it only occurs once

@yb6599 @malachitewind