### PR TITLE
ENH: Add _load_trial_params

### DIFF
--- a/mitosis/tests/test_all.py
+++ b/mitosis/tests/test_all.py
@@ -142,6 +142,8 @@ def test_mock_experiment(mock_steps, tmp_path):
     )
     data = mitosis.load_trial_data(exp_key, trials_folder=tmp_path)
     assert len(data[0]["data"]) == 5
+    params = mitosis._load_trial_params(exp_key, step=0, trials_folder=tmp_path)
+    assert params == {"length": 5, "extra": True}
     metadata = mitosis._disk.locate_trial_folder(exp_key, trials_folder=tmp_path)
     assert (metadata / "experiment").resolve().exists()
 


### PR DESCRIPTION
Sometimes its useful to load the exact parameters used in a function.

This function is provisional, as it relies on a hack: dependence between the specific ordering of cells in a created trial source and where to stop executing a trial's source if just loading its parameters.  That's a bit of spooky action at a distance.

It also has all the uncertainty of unpickling an object in a different environment/version of python.  A better implementation would be to actually pickle the parameters rather than search through the source for the code that creates them.

Thus, this is a WIP