### PR TITLE
Upgrade to sqlalchemy 2.0, fixing failure to commit

### DIFF
--- a/mitosis/__init__.py
+++ b/mitosis/__init__.py
@@ -157,7 +157,7 @@ class DBHandler(logging.Handler):
         self.log_table = Table(table_name, md, *cols)
         url = "sqlite:///" + str(self.db)
         self.eng = create_engine(url)
-        with self.eng.connect() as conn:
+        with self.eng.begin() as conn:
             if not inspection.inspect(conn).has_table(table_name):
                 md.create_all(conn)
 
@@ -182,7 +182,7 @@ class DBHandler(logging.Handler):
                         stmt = stmt.values({col: vals[i + 1]})
         else:
             raise ValueError("Cannot parse db message")
-        with self.eng.connect() as conn:
+        with self.eng.begin() as conn:
             conn.execute(stmt)
 
     def parse_record(self, msg: str) -> List[str]:
@@ -234,7 +234,7 @@ def _verify_variant_name(trial_db: Path, step: str, param: Parameter) -> None:
     ind_equal = df.loc[:, "name"] == param.var_name
     if ind_equal.sum() == 0:
         stmt = tb.insert().values({"name": param.var_name, "params": str(vals)})
-        with eng.connect() as conn:
+        with eng.begin() as conn:
             conn.execute(stmt)
     elif df.loc[ind_equal, "params"].iloc[0] != str(vals):
         raise RuntimeError(

--- a/mitosis/tests/mock_paper.py
+++ b/mitosis/tests/mock_paper.py
@@ -1,3 +1,8 @@
+from collections import defaultdict
+
 data_config = {"length": {"test": 5}}
 
 meth_config = {"metric": {"test": "len"}}
+
+# lookup any parameter, any variant: always none
+lookup_default = defaultdict(lambda: defaultdict(lambda: None))

--- a/mitosis/tests/mock_part1.py
+++ b/mitosis/tests/mock_part1.py
@@ -14,3 +14,8 @@ class Klass:
         getLogger(__name__).debug("This is run in debug mode only")
 
         return {"data": np.ones(length, dtype=np.float_), "extra": extra}
+
+
+def do_nothing(*args, **kwargs) -> dict[str, None]:
+    """An experiment step that accepts anything and produces nothing"""
+    return {"main": None}

--- a/mitosis/tests/test_pyproject.toml
+++ b/mitosis/tests/test_pyproject.toml
@@ -1,4 +1,7 @@
 [tool.mitosis.steps]
+nothing = [
+    "mitosis.tests.mock_part1:do_nothing",
+    "mitosis.tests.mock_paper:lookup_default"]
 data = [
     "mitosis.tests.mock_part1:Klass.gen_data",
     "mitosis.tests.mock_paper:data_config"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
   "nbclient",
   "nbformat",
   "pandas<2.2",
-  "sqlalchemy",
+  "sqlalchemy>=1.4",
   "toml",
   "types-toml",
 ]


### PR DESCRIPTION
As of sqlalchemy 2.0, default behavior for a connection is to auto-rollback
unless explicitly committed or part of a transaction (begun with begin()).
